### PR TITLE
added possibility of manage navigation timeout

### DIFF
--- a/packages/whatsapp_bot_flutter/lib/src/whatsapp_bot_flutter_src.dart
+++ b/packages/whatsapp_bot_flutter/lib/src/whatsapp_bot_flutter_src.dart
@@ -27,6 +27,7 @@ class WhatsappBotFlutter {
     int qrCodeWaitDurationSeconds = 60,
     List<String>? puppeteerArgs,
     String? linkWithPhoneNumber,
+    Duration? puppeteerNavigationTimeout,
     Function(String code)? onPhoneLinkCode,
     Duration connectionTimeout = const Duration(seconds: 20),
     Duration wppInitTimeout = const Duration(seconds: 15),
@@ -84,7 +85,8 @@ class WhatsappBotFlutter {
 
       await page.setBypassCSP(true);
       await page.setUserAgent(WhatsAppMetadata.userAgent);
-      await page.goto(WhatsAppMetadata.whatsAppURL);
+      await page.goto(WhatsAppMetadata.whatsAppURL,
+          timeout: puppeteerNavigationTimeout);
 
       wpClient = WpClientDesktop(page: page, browser: browser);
 


### PR DESCRIPTION
adds the possibility of increasing puppeteer's navigation timeout, so on PCs that take a while to load the page, it works more stable.



Solution on stackoverflow for pupeetter, i just added to your lib:
[link](https://stackoverflow.com/questions/52163547/node-js-puppeteer-how-to-set-navigation-timeout#:~:text=The%20default%20in%20puppeteer%20timeout,cases%20is%20specified%20in%20milliseconds.)